### PR TITLE
Fix duplicate icon generation

### DIFF
--- a/utils/generate-icons.js
+++ b/utils/generate-icons.js
@@ -75,5 +75,3 @@ async function generatePNGs() {
 }
 
 generatePNGs();
-
-generatePNGs();


### PR DESCRIPTION
## Summary
- call `generatePNGs` once in the icon generation script

## Testing
- `npm run lint` *(fails: `@typescript-eslint` rules not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f836ea3a8832992bd72c497115249